### PR TITLE
Fix SSP playback when auth is PAM

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -136,7 +136,7 @@ class ShinySession(val sessionId: Int,
     private fun maybeLogin() {
         credentials?.let { (username, password) ->
             if (isProtected(httpUrl)) {
-                cookieStore.addCookie(postLogin(httpUrl, username, password))
+                postLogin(httpUrl, username, password, cookies = cookieStore)
             } else {
                 info("SHINYCANNON_USER and SHINYCANNON_PASS set, but target app doesn't require authentication.")
             }


### PR DESCRIPTION
Apache HttpClient after version 4.3 doesn't send client cookies the Domain fields of which aren't set. This fix modifies every cookie before sending it so that its Domain corresponds to the host of the authentication request.

This resolves a `invalid csrf token` error that exhibited itself in SSP when auth was PAM. I don't know why exactly this problem didn't exhibit itself earlier, when auth was anything other than PAM.

I did find that the error message comes from the `csurf` library, so my best guess is that library is only used in the PAM path for some reason.