### PR TITLE
Fix debug logging calls

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -262,9 +262,9 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                     it.addListener(object : WebSocketAdapter() {
                         override fun onTextMessage(sock: WebSocket, msg: String) {
                             if (canIgnore(msg)) {
-                                session.logger.debug { "%%% Ignoring $msg" }
+                                session.logger.debug("%%% Ignoring $msg")
                             } else {
-                                session.logger.debug { "%%% Received: $msg" }
+                                session.logger.debug("%%% Received: $msg")
                                 if (!session.receiveQueue.offer(session.replaceTokens(msg))) {
                                     throw Exception("receiveQueue is full (max = ${session.receiveQueueSize})")
                                 }
@@ -299,7 +299,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                 // Waits indefinitely for a message to become available
                 // TODO Look into how to shut down properly for each WS_RECV_* type. Consider shutdown exception or shutdown sentinel
                 val receivedStr = session.receiveQueue.take()
-                session.logger.debug { "WS_RECV received: $receivedStr" }
+                session.logger.debug("WS_RECV received: $receivedStr")
                 // Because the messages in our log file are extra-escaped, we need to unescape once.
                 val expectingStr = session.replaceTokens(message)
                 val expectingObj = parseMessage(expectingStr)
@@ -325,7 +325,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
             return tryLog(session, out) {
                 // Waits indefinitely for a message to become available
                 val receivedStr = session.receiveQueue.take()
-                session.logger.debug { "WS_RECV_INIT received: $receivedStr" }
+                session.logger.debug("WS_RECV_INIT received: $receivedStr")
 
                 val sessionId = parseMessage(receivedStr)
                         ?.get("config")
@@ -335,7 +335,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                         ?: throw IllegalStateException("Expected sessionId from WS_RECV_INIT message")
 
                 session.tokenDictionary["SESSION"] = sessionId
-                session.logger.debug { "WS_RECV_INIT got SESSION: ${session.tokenDictionary["SESSION"]}" }
+                session.logger.debug("WS_RECV_INIT got SESSION: ${session.tokenDictionary["SESSION"]}")
             }
         }
     }
@@ -347,7 +347,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
             return tryLog(session, out) {
                 // Waits indefinitely for a message to become available
                 val receivedStr = session.receiveQueue.take()
-                session.logger.debug { "WS_RECV_BEGIN_UPLOAD received: $receivedStr" }
+                session.logger.debug("WS_RECV_BEGIN_UPLOAD received: $receivedStr")
 
                 val jobId = parseMessage(receivedStr)
                         ?.get("response")
@@ -360,7 +360,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
 
                 session.tokenDictionary["UPLOAD_JOB_ID"] = jobId
 
-                session.logger.debug { "WS_RECV_BEGIN_UPLOAD got jobId: $jobId" }
+                session.logger.debug("WS_RECV_BEGIN_UPLOAD got jobId: $jobId")
             }
         }
     }
@@ -375,7 +375,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
             return tryLog(session, out) {
                 val text = session.replaceTokens(message)
                 session.webSocket!!.sendText(text)
-                session.logger.debug { "WS_SEND sent: $text" }
+                session.logger.debug("WS_SEND sent: $text")
             }
         }
     }
@@ -388,7 +388,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
         override fun handle(session: ShinySession, out: PrintWriter): Boolean {
             return tryLog(session, out) {
                 session.webSocket!!.disconnect()
-                session.logger.debug { "WS_CLOSE sent" }
+                session.logger.debug("WS_CLOSE sent")
             }
         }
     }


### PR DESCRIPTION
These calls were valid with the old kotlin logging lib API we used to use because it expected a "block", but the Java logging API we're using now just casts the block to a string, producing nonsense like this:

`DEBUG [ReadingThread] 2018-08-08 01:39:22,651 (Events.kt:265) - Function0<java.lang.String>`

Now, we're back to just logging strings, and the messages show up in debug.log again.