### PR TITLE
Custom user-agent string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ packages: $(RPM_FILE) $(DEB_FILE) $(JAR_FILE) $(BIN_FILE)
 # $(VERSION_FILE) is embededed in the jar to provide the version at runtime.
 $(MAVEN_UBERJAR):
 	mvn package
-	$(shell echo -n $(VERSION)-$(GIT_SHA) > $(VERSION_FILE))
+	echo -n $(VERSION)-$(GIT_SHA) > $(VERSION_FILE)
 	jar uf $(MAVEN_UBERJAR) $(VERSION_FILE)
 	rm -f $(VERSION_FILE)
 
@@ -59,7 +59,7 @@ RELEASE.txt:
 
 RELEASE_URLS.txt: RELEASE.txt
 	rm -f $@
-	echo https://s2.amazonaws.com/rstudio-shinycannon-build/$(shell cat $<)/deb/$(DEB_FILE) >> $@
+	echo https://s3.amazonaws.com/rstudio-shinycannon-build/$(shell cat $<)/deb/$(DEB_FILE) >> $@
 	echo https://s3.amazonaws.com/rstudio-shinycannon-build/$(shell cat $<)/rpm/$(RPM_FILE) >> $@
 	echo https://s3.amazonaws.com/rstudio-shinycannon-build/$(shell cat $<)/jar/$(JAR_FILE) >> $@
 	echo https://s3.amazonaws.com/rstudio-shinycannon-build/$(shell cat $<)/bin/$(BIN_FILE) >> $@

--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -137,6 +137,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                     .create()
                     .setDefaultCookieStore(session.cookieStore)
                     .setDefaultRequestConfig(cfg)
+                    .setUserAgent(getUserAgent())
                     .build()
             val get = HttpGet(url)
             client.execute(get).use { response ->
@@ -219,6 +220,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                             .create()
                             .setDefaultCookieStore(session.cookieStore)
                             .setDefaultRequestConfig(cfg)
+                            .setUserAgent(getUserAgent())
                             .build()
                     val post = HttpPost(url)
 
@@ -284,6 +286,8 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                             .cookies
                             .map { "${it.name}=${it.value}" }
                             .joinToString("; "))
+
+                    it.addHeader("user-agent", getUserAgent())
 
                     it.connect()
                 }

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -373,6 +373,8 @@ fun getVersion() = Thread.currentThread()
         .contextClassLoader
         .getResource("shinycannon-version.txt")?.readText() ?: "development"
 
+fun getUserAgent() = "shinycannon/${getVersion()}"
+
 fun main(args: Array<String>) = mainBody("shinycannon") {
 
     Args(ArgParser(args, helpFormatter = DefaultHelpFormatter(

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -328,6 +328,10 @@ class EnduranceTest(val args: Sequence<String>,
         finishedCountdown.await()
         keepShowingStats.set(false)
         // TODO make the stats thing update in place, and look cool too maybe?
+
+        // Workaround until https://github.com/TakahikoKawasaki/nv-websocket-client/pull/169 is merged or otherwise fixed.
+        // Timers in the websocket code hold up the JVM, so we must explicity terminate.
+        exitProcess(0);
     }
 
 }

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -410,6 +410,7 @@ fun main(args: Array<String>) = mainBody("shinycannon") {
 
         output.mkdirs()
         output.toPath().resolve("sessions").toFile().mkdir()
+        output.toPath().resolve("shinycannon-version.txt").toFile().writeText(getVersion())
 
         // This appender prints DEBUG and above to debug.log and is added to the
         // global logger.

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
 import kotlin.collections.ArrayList
 import kotlin.concurrent.thread
+import kotlin.system.exitProcess
 
 fun readRecording(recording: File): ArrayList<Event> {
     return recording.readLines()
@@ -361,9 +362,15 @@ fun recordingDuration(recording: File): Long {
     return events.last().begin - events.first().begin
 }
 
-fun main(args: Array<String>) = mainBody("shinycannon") {
+// shinycannon-version.txt is added to the .jar by the Makefile. If the code is built by other means (like IntelliJ),
+// that file won't be on the classpath.
+fun getVersion() = Thread.currentThread()
+        .contextClassLoader
+        .getResource("shinycannon-version.txt")?.let {
+            it.readText()
+        } ?: "development"
 
-    Thread.currentThread().name = "thread00"
+fun main(args: Array<String>) = mainBody("shinycannon") {
 
     Args(ArgParser(args, helpFormatter = DefaultHelpFormatter(
             prologue = "shinycannon is a load generation tool for use with Shiny Server Pro and RStudio Connect.",
@@ -371,8 +378,12 @@ fun main(args: Array<String>) = mainBody("shinycannon") {
                 environment variables:
                   SHINYCANNON_USER
                   SHINYCANNON_PASS
+
+                version: ${getVersion()}
                 """.trimIndent()
     ))).run {
+
+        Thread.currentThread().name = "thread00"
 
         val recording = File(recordingPath)
         check(recording.isFile && recording.exists())

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -371,9 +371,7 @@ fun recordingDuration(recording: File): Long {
 // that file won't be on the classpath.
 fun getVersion() = Thread.currentThread()
         .contextClassLoader
-        .getResource("shinycannon-version.txt")?.let {
-            it.readText()
-        } ?: "development"
+        .getResource("shinycannon-version.txt")?.readText() ?: "development"
 
 fun main(args: Array<String>) = mainBody("shinycannon") {
 


### PR DESCRIPTION
shinycannon now reports a `user-agent` of `shinycannon/<version>`, where `<version>` looks like `1.0.0-22cb125` or similar.

Should be merged after #11.