### PR TITLE
Better error message when recording file is missing

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -393,7 +393,10 @@ fun main(args: Array<String>) = mainBody("shinycannon") {
         Thread.currentThread().name = "thread00"
 
         val recording = File(recordingPath)
-        check(recording.isFile && recording.exists())
+
+        if (!(recording.exists() && recording.isFile)) {
+            error("recording '${recording}' doesn't exist or is not a file")
+        }
 
         // If a startInterval was supplied, then use it. Otherwise, compute
         // based on the length of the recording and the number of workers.


### PR DESCRIPTION
Prior to this PR, shinycannon emits a cryptic error when the specified recording file doesn't exist:

```
SHINYCANNON_USER=pamtest SHINYCANNON_PASS=pamtest shinycannon recording/centos7_pamauth_05_r.log http://192.168.40.5:3838/05_sliders/ --workers 5 --output-dir centos705pamtestrec_playback_onubuntu18 
Exception in thread "thread00" java.lang.IllegalStateException: Check failed.
    at com.rstudio.shinycannon.MainKt$main$1.invoke(Main.kt:396)
    at com.rstudio.shinycannon.MainKt$main$1.invoke(Main.kt)
    at com.xenomachina.argparser.SystemExitExceptionKt.mainBody(SystemExitException.kt:71)
    at com.xenomachina.argparser.SystemExitExceptionKt.mainBody$default(SystemExitException.kt:69)
    at com.rstudio.shinycannon.MainKt.main(Main.kt:380)
```

Now, the error looks like this if the recording doesn't exist or if it points to a directory instead of a file:

```
alandipert@frito~/g/r/shinycannon➜ java -jar target/shinycannon-1.0.0-jar-with-dependencies.jar reciording.log https://beta.rstudioconnect.com/content/3843/ --workers 1 --log-level info --output-dir test --overwrite-output
Exception in thread "thread00" java.lang.IllegalStateException: recording 'reciording.log' doesn't exist or is not a file
	at com.rstudio.shinycannon.MainKt$main$1.invoke(Main.kt:398)
	at com.rstudio.shinycannon.MainKt$main$1.invoke(Main.kt)
	at com.xenomachina.argparser.SystemExitExceptionKt.mainBody(SystemExitException.kt:71)
	at com.xenomachina.argparser.SystemExitExceptionKt.mainBody$default(SystemExitException.kt:69)
	at com.rstudio.shinycannon.MainKt.main(Main.kt:380)
```