### PR TITLE
Exit summary

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -393,7 +393,10 @@ fun main(args: Array<String>) = mainBody("shinycannon") {
         Thread.currentThread().name = "thread00"
 
         val recording = File(recordingPath)
-        check(recording.isFile && recording.exists())
+
+        if (!(recording.exists() && recording.isFile)) {
+            error("recording '${recording}' doesn't exist or is not a file")
+        }
 
         // If a startInterval was supplied, then use it. Otherwise, compute
         // based on the length of the recording and the number of workers.

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -328,6 +328,8 @@ class EnduranceTest(val args: Sequence<String>,
         finishedCountdown.await()
         keepShowingStats.set(false)
         // TODO make the stats thing update in place, and look cool too maybe?
+        
+        logger.info("Complete. Failed: ${stats.stats[Stats.State.FAIL]}, Done: ${stats.stats[Stats.State.DONE]}")
 
         // Workaround until https://github.com/TakahikoKawasaki/nv-websocket-client/pull/169 is merged or otherwise fixed.
         // Timers in the websocket code hold up the JVM, so we must explicity terminate.


### PR DESCRIPTION
(should be merged after #13)

Currently, the thread that prints status output prints a line every 5 seconds. Because it's on a timer, it might not be the last thing to produce output, and so when `shinycannon` exits it's not obvious that it exited normally or what the final stats were.

This adds a line to the console output with final stats right before exiting the JVM, making it clear that the program is shutting down, and how many completed/failed sessions there were.

Before, the last few lines of output might look like this:
```
...
2018-09-11 13:35:13.583 INFO [progress] - Running: 4, Failed: 0, Done: 6
2018-09-11 13:35:13.796 INFO [thread07] - Stopped
2018-09-11 13:35:14.863 INFO [thread08] - Stopped
2018-09-11 13:35:15.796 INFO [thread09] - Stopped
2018-09-11 13:35:16.939 INFO [thread10] - Stopped
$
```
Now, the last few lines look like this:
```
...
2018-09-11 13:35:13.583 INFO [progress] - Running: 4, Failed: 0, Done: 6
2018-09-11 13:35:13.796 INFO [thread07] - Stopped
2018-09-11 13:35:14.863 INFO [thread08] - Stopped
2018-09-11 13:35:15.796 INFO [thread09] - Stopped
2018-09-11 13:35:16.939 INFO [thread10] - Stopped
2018-09-11 13:35:16.939 INFO [thread00] - Complete. Failed: 0, Done: 10
$
```