### PR TITLE
Emit CLI args as JSON at the 2nd line of session CSVs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit</artifactId>
             <version>${kotlin.version}</version>
             <scope>test</scope>

--- a/shinycannon.iml
+++ b/shinycannon.iml
@@ -30,6 +30,7 @@
     <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.2.60" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.2.60" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-reflect:1.2.60" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test-junit:1.2.60" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test-annotations-common:1.2.60" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.2.60" level="project" />

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -1,7 +1,6 @@
 package com.rstudio.shinycannon
 
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
+import com.google.gson.*
 import com.neovisionaries.ws.client.WebSocket
 import com.xenomachina.argparser.ArgParser
 import com.xenomachina.argparser.DefaultHelpFormatter
@@ -13,6 +12,7 @@ import org.apache.log4j.*
 import java.io.File
 import java.io.PrintWriter
 import java.lang.Exception
+import java.lang.reflect.Type
 import java.math.BigDecimal
 import java.nio.file.Paths
 import java.security.SecureRandom
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
 import kotlin.collections.ArrayList
 import kotlin.concurrent.thread
+import kotlin.reflect.full.declaredMemberProperties
 import kotlin.system.exitProcess
 
 fun readRecording(recording: File): ArrayList<Event> {
@@ -246,7 +247,8 @@ fun getCreds() = listOf("SHINYCANNON_USER", "SHINYCANNON_PASS")
         ?.zipWithNext()
         ?.first()
 
-class EnduranceTest(val args: Sequence<String>,
+class EnduranceTest(val argsStr: String,
+                    val argsJson: String,
                     val httpUrl: String,
                     val recording: File,
                     // Amount of time to wait between starting workers until target reached
@@ -281,7 +283,8 @@ class EnduranceTest(val args: Sequence<String>,
             val session = ShinySession(sessionId, workerId, iterationId, httpUrl, recording, log, logger, getCreds())
             val outputFile = makeOutputFile(sessionId, workerId, iterationId)
             outputFile.printWriter().use { out ->
-                out.println("# " + args.joinToString(" "))
+                out.println("# " + argsStr)
+                out.println("# " + argsJson)
                 out.printCsv(*columnNames)
                 out.printCsv(sessionId, workerId, iterationId, "PLAYER_SESSION_CREATE", nowMs(), 0, "")
                 session.run(delay, out, stats)
@@ -359,6 +362,26 @@ class Args(parser: ArgParser) {
     val logLevel by parser.storing("Log level (default: warn, available include: debug, info, warn, error)") {
         Level.toLevel(this.toUpperCase(), Level.WARN) as Level
     }.default(Level.WARN)
+}
+
+class ArgsSerializer(): JsonSerializer<Args> {
+    override fun serialize(args: Args, type: Type, ctx: JsonSerializationContext): JsonElement {
+        val jsonObject = JsonObject()
+        args.javaClass.kotlin.declaredMemberProperties.forEach {
+            when (it.returnType.toString()) {
+                "kotlin.String",
+                "org.apache.log4j.Level!" -> jsonObject.addProperty(it.name, it.get(args).toString())
+                "kotlin.Boolean" -> jsonObject.addProperty(it.name, it.get(args) as Boolean)
+                "kotlin.Long?" -> jsonObject.addProperty(it.name, it.get(args) as kotlin.Long?)
+                "kotlin.Int?" -> jsonObject.addProperty(it.name, it.get(args) as kotlin.Int?)
+                "kotlin.Long" -> jsonObject.addProperty(it.name, it.get(args) as kotlin.Long)
+                "kotlin.Int" -> jsonObject.addProperty(it.name, it.get(args) as kotlin.Int)
+                "java.math.BigDecimal!" -> jsonObject.addProperty(it.name, (it.get(args) as BigDecimal).toFloat())
+                else -> error("Don't know how to JSON-serialize argument type: ${it.returnType}")
+            }
+        }
+        return jsonObject;
+    }
 }
 
 val logPattern = "%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%t] - %m%n"
@@ -469,7 +492,11 @@ fun main(args: Array<String>) = mainBody("shinycannon") {
 
         val loadTest = EnduranceTest(
                 // Drop the original logpath from the arglist
-                args.asSequence().drop(1),
+                args.asSequence().drop(1).joinToString(" "),
+                GsonBuilder()
+                        .registerTypeAdapter(Args::class.java, ArgsSerializer())
+                        .create()
+                        .toJson(this),
                 appUrl,
                 recording,
                 numWorkers = workers,


### PR DESCRIPTION
We already add the CLI arguments as a comment at the top of session recording `.csv` files. This enhancement adds an additional comment line that contains a JSON object representing the arguments.

The tops of session files now look like this:

```
alandipert@frito~/g/r/s/q/sessions➜ head -10 0_0_0.csv
# http://localhost:3838/sample-apps/hello/ --workers 10 --output-dir qa-425 --overwrite-output
# {"appUrl":"http://localhost:3838/sample-apps/hello/","debugLog":false,"loadedDurationMinutes":0.0,"logLevel":"WARN","outputDir":"qa-425","overwriteOutput":true,"recordingPath":"../shinyloadtest/recording.log","workers":10}
session_id,worker_id,iteration,event,timestamp,input_line_number,comment
0,0,0,PLAYER_SESSION_CREATE,1537482856562,0,
0,0,0,REQ_HOME_START,1537482856562,3,
0,0,0,REQ_HOME_END,1537482857590,3,
0,0,0,REQ_GET_START,1537482857590,4,
0,0,0,PLAYBACK_FAIL,1537482857660,4,
```

Doing this, I realized it's kind of weird that we're putting argument information at the top of every CSV instead of into a single special-purpose metadata file in the recording output directory. We might consider doing that instead in the future.