### PR TITLE
Improve help output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGES.md merge=union

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## master
+
+* Improved help output ([#24][24], [#27][27])
+
+[24]: https://github.com/rstudio/shinycannon/pull/24
+[27]: https://github.com/rstudio/shinycannon/pull/27

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -465,7 +465,9 @@ fun initLogging(debugLog: Boolean, debugLogFile: String, logLevel: Level): Logge
     return LogManager.getLogger("shinycannon")
 }
 
-fun main(args: Array<String>) = mainBody("shinycannon") {
+fun main(userArgs: Array<String>) = mainBody("shinycannon") {
+
+    val args = if (userArgs.size == 0) arrayOf("-h") else userArgs
 
     Args(ArgParser(args, helpFormatter = DefaultHelpFormatter(
             prologue = """

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -468,7 +468,16 @@ fun initLogging(debugLog: Boolean, debugLogFile: String, logLevel: Level): Logge
 fun main(args: Array<String>) = mainBody("shinycannon") {
 
     Args(ArgParser(args, helpFormatter = DefaultHelpFormatter(
-            prologue = "shinycannon is a load generation tool for use with Shiny Server Pro and RStudio Connect.",
+            prologue = """
+                shinycannon is a load generation tool for use with Shiny Server Pro and RStudio Connect.
+
+                Provided a recording file (made with the shinyloadtest package and typically named recording.log), and the URL of a deployed application, shinycannon will "play back" the recording against the application, simulating one or more users interacting with the application over a configurable amount of time.
+
+                For example, to simulate 3 users interacting with the application for no less than 10 minutes, the following command could be used:
+
+                shinycannon recording.log https://rsc.example.com/content/123 --workers 3 --loaded-duration-minutes 10
+
+            """.trimIndent(),
             epilogue = """
                 environment variables:
                   SHINYCANNON_USER


### PR DESCRIPTION
This PR makes two minor changes to help output:

1. If no arguments are provided, help output is displayed as if `-h` or `--help` was passed
1. Help output now contains a brief description of the shinycannon functionality and a usage example

Fixes #24