### PR TITLE
Fix SSP detection

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Detect.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Detect.kt
@@ -31,13 +31,13 @@ fun servedBy(appUrl: String, logger: Logger): ServerType {
         return ServerType.SAI
 
     val resp = slurp(HttpGet(appUrl))
+    val headers = resp.headers.mapKeys { (k, v) -> k.toLowerCase() }
 
-    if (resp.headers.containsKey("SSP-XSRF")) {
+    if (headers.containsKey("ssp-xsrf")) {
         return ServerType.SSP
-    } else if (resp.headers.containsKey("x-powered-by")) {
+    } else if (headers.containsKey("x-powered-by")) {
         val sspVals = setOf("Express", "Shiny Server", "Shiny Server Pro")
-        if (sspVals.contains(resp.headers["x-powered-by"]))
-            return ServerType.SSP
+        if (sspVals.contains(headers["x-powered-by"])) return ServerType.SSP
     } else if (resp.cookies.cookies.firstOrNull { it.name == "rscid" } != null) {
         return ServerType.RSC
     }


### PR DESCRIPTION
#36 broke SSP detection because headers in the detection response weren't being downcased, and we were looking for lowercase header names.

It was working for non-authenticated apps, which is how it probably slipped past us, because our first heuristic (looking for SSP-XSRF) was working. With auth on, there is no SSP-XSRF during our detection request, and our second heuristic (looking for `x-powered-by`) failed because the actual header was cased `X-Powered-By`.

This fixes the problem by lower-casing headers before we start working with them.