### PR TITLE
Consolidate cookie/header massage code; fix SSP detection

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Detect.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Detect.kt
@@ -33,13 +33,12 @@ fun servedBy(appUrl: String, logger: Logger): ServerType {
         return ServerType.SAI
 
     val resp = slurp(HttpGet(appUrl))
-    val headers = resp.headers.mapKeys { (k, v) -> k.toLowerCase() }
 
-    if (headers.containsKey("x-ssp-xsrf") || resp.hasCookie("SSP-XSRF")) {
+    if (resp.hasHeader("x-ssp-xsrf") || resp.hasCookie("SSP-XSRF")) {
         return ServerType.SSP
-    } else if (headers.containsKey("x-powered-by")) {
+    } else if (resp.hasHeader("x-powered-by")) {
         val sspVals = setOf("Express", "Shiny Server", "Shiny Server Pro")
-        if (sspVals.contains(headers["x-powered-by"])) return ServerType.SSP
+        if (sspVals.contains(resp.getHeader("x-powered-by"))) return ServerType.SSP
     } else if (resp.hasCookie("rscid")) {
         return ServerType.RSC
     }

--- a/src/main/kotlin/com/rstudio/shinycannon/Detect.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Detect.kt
@@ -1,6 +1,8 @@
 package com.rstudio.shinycannon
 
 import net.moznion.uribuildertiny.URIBuilderTiny
+import org.apache.http.HttpResponse
+import org.apache.http.client.CookieStore
 import org.apache.http.client.methods.HttpGet
 import org.apache.logging.log4j.Logger
 import kotlin.system.exitProcess
@@ -33,12 +35,12 @@ fun servedBy(appUrl: String, logger: Logger): ServerType {
     val resp = slurp(HttpGet(appUrl))
     val headers = resp.headers.mapKeys { (k, v) -> k.toLowerCase() }
 
-    if (headers.containsKey("ssp-xsrf")) {
+    if (headers.containsKey("x-ssp-xsrf") || resp.hasCookie("SSP-XSRF")) {
         return ServerType.SSP
     } else if (headers.containsKey("x-powered-by")) {
         val sspVals = setOf("Express", "Shiny Server", "Shiny Server Pro")
         if (sspVals.contains(headers["x-powered-by"])) return ServerType.SSP
-    } else if (resp.cookies.cookies.firstOrNull { it.name == "rscid" } != null) {
+    } else if (resp.hasCookie("rscid")) {
         return ServerType.RSC
     }
 

--- a/src/main/kotlin/com/rstudio/shinycannon/ProtectedApp.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/ProtectedApp.kt
@@ -30,8 +30,8 @@ class HttpResponse(val statusCode: Int,
                    val body: String) {
     fun getCookie(name: String) = this.cookieStore.cookies.firstOrNull { it.name == name }
     fun hasCookie(name: String) = this.getCookie(name) != null
-    fun getHeader(name: String) = this.headers.get(name)
-    fun hasHeader(name: String) = this.headers.containsKey(name)
+    fun getHeader(name: String) = this.headers.get(name.toLowerCase())
+    fun hasHeader(name: String) = this.headers.containsKey(name.toLowerCase())
     companion object {
         fun from(response: org.apache.http.HttpResponse, cookies: BasicCookieStore): HttpResponse {
             return HttpResponse(

--- a/src/main/kotlin/com/rstudio/shinycannon/ProtectedApp.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/ProtectedApp.kt
@@ -30,6 +30,8 @@ class HttpResponse(val statusCode: Int,
                    val body: String) {
     fun getCookie(name: String) = this.cookieStore.cookies.firstOrNull { it.name == name }
     fun hasCookie(name: String) = this.getCookie(name) != null
+    fun getHeader(name: String) = this.headers.get(name)
+    fun hasHeader(name: String) = this.headers.containsKey(name)
     companion object {
         fun from(response: org.apache.http.HttpResponse, cookies: BasicCookieStore): HttpResponse {
             return HttpResponse(


### PR DESCRIPTION
Previously one of the SSP detection heuristics was to look for the `ssp-xsrf` header in the initial request's response.

This was wrong, because SSP actually sends the header `x-ssp-xsrf`. `SSP-XSRF` is the name of the cookie it sends.

Note that header names are case sensitive but cookie names are not. Throughout the code, headers are normalized to lower-case.

This change fixes SSP detection by looking for the `x-ssp-xsrf` header, and augments the heuristic by additionally looking for the `SSP-XSRF` cookie.

Refs Trello: https://trello.com/c/pNDKc7DC/1114-shinycannon-ssp-detection-broken