### PR TITLE
Remove the app URL query string before constructing the websocket URL

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -252,7 +252,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
             check(session.webSocket == null) { "Tried to WS_OPEN but already have a websocket" }
 
             withLog(session, out) {
-                val wsUrl = session.wsUrl + session.replaceTokens(url)
+                val wsUrl = session.wsUrl.appendRawPathsByString(session.replaceTokens(url)).build()
                 session.webSocket = WebSocketFactory().createSocket(wsUrl).also {
                     it.addListener(object : WebSocketAdapter() {
                         override fun onTextMessage(sock: WebSocket, msg: String) {

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -115,12 +115,16 @@ class ShinySession(val sessionId: Int,
         receiveQueue.offer(WSMessage.Error(cause))
     }
 
-    val wsUrl: String = URIBuilderTiny(httpUrl).let { uri ->
-        uri.setScheme(when (uri.scheme) {
+    val wsUrl: URIBuilderTiny = URIBuilderTiny(httpUrl).let { uri ->
+        val scheme = when (uri.scheme) {
             "http" -> "ws"
             "https" -> "wss"
             else -> error("Unknown scheme: ${uri.scheme}")
-        }).build().toString()
+        }
+        uri
+            .setScheme(scheme)
+            // There may be extant query parameters if the app URL included included them for bookmarking; we must clear them.
+            .setQueryParameters(emptyMap<String, String>())
     }
 
     val allowedTokens: HashSet<String> = hashSetOf("WORKER", "TOKEN", "ROBUST_ID", "SOCKJSID", "SESSION", "UPLOAD_URL", "UPLOAD_JOB_ID")


### PR DESCRIPTION
This fixes an error that occurs when one attempts to load test an application that has query parameters in its URL (such as when URL bookmarking is used). The parameters must be stripped in order to construct the correct Websocket URL.

Refs trello https://trello.com/c/t9LGKYh5/1200-shinycannon-query-bookmark-error-error-thread01-playback-failed-the-status-code-of-the-opening-handshake-response-is-not-101-swi