### PR TITLE
File/directory handling tweaks

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -507,12 +507,6 @@ fun main(userArgs: Array<String>) = mainBody("shinycannon") {
 
         if (output.exists()) {
             if (overwriteOutput) {
-                // Ensure the existing directory we're about to delete is conceivably an output directory.
-                check(listOf("recording.log", "sessions").map {
-                    output.toPath().resolve(it).toFile()
-                }.all { it.exists() }, {
-                    "Directory doesn't look like an output directory, so not overwriting. Please delete it manually."
-                })
                 output.deleteRecursively()
             } else {
                 error("Output dir $outputDir already exists and --overwrite-output not set")

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -501,6 +501,12 @@ fun main(userArgs: Array<String>) = mainBody("shinycannon") {
                 """.trimIndent()
     ))).run {
 
+        val recording = File(recordingPath)
+
+        if (!(recording.exists() && recording.isFile)) {
+            error("recording '${recording}' doesn't exist or is not a file")
+        }
+
         Thread.currentThread().name = "thread00"
 
         val output = File(outputDir)
@@ -514,12 +520,6 @@ fun main(userArgs: Array<String>) = mainBody("shinycannon") {
         }
 
         val appLogger = initLogging(debugLog, output.toPath().resolve("debug.log").toString(), logLevel)
-
-        val recording = File(recordingPath)
-
-        if (!(recording.exists() && recording.isFile)) {
-            error("recording '${recording}' doesn't exist or is not a file")
-        }
 
         // If a startInterval was supplied, then use it. Otherwise, compute
         // based on the length of the recording and the number of workers.


### PR DESCRIPTION
There are two minor changes here that make interaction with the recording file and output directory more intuitive.

## 1. If the recording file doesn't exist, don't create the output directory.

Previously, even if the specified recording file didn't exist, an error was printed and `shinycannon` would exit. However, the output directory would still be created, and populated with `debug.log` if `--debug-log` was specified.

Shalu and I both found this counter-intuitive. It didn't make sense for an output directory to be created when there was no possible interesting output data to store.

Now, existence of the file is checked before any output directory or log files are created, and `shinycannon` exits immediately without creating any directories or files if the recording file doesn't exist.

## 2. Respect `--overwrite-output`.

Previously, even if `--overwrite-output` was specified -- indicating that the output directory should be deleted and recreated even it exists already -- `shinycannon` would still refuse to delete the output directory if it didn't contain files that an output directory normally would contain.

The original idea with this was, we would have this extra safeguard ensuring people didn't accidentally delete directories that contained important data unrelated to shinycannon. In practice though, it's just annoying.

Since the user is explicitly specifying `--overwrite-output`, we should assume they know what they're doing, and not confuse them with an error message.