### PR TITLE
Misc fixes

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -127,8 +127,9 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                       open val status: Int) : Event(begin, lineNumber) {
 
         fun statusEquals(status: Int): Boolean {
-            val equalCodes = setOf(200, 304)
-            return equalCodes.union(setOf(this.status, status)) == equalCodes
+            return this.status == status
+                    || (this.status == 200 && status == 302)
+                    || (this.status == 302 && status == 200)
         }
 
         // TODO Candidate for becoming a method on ShinySession that takes url/status args
@@ -149,7 +150,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
             client.execute(get).use { response ->
                 val body = EntityUtils.toString(response.entity)
                 val gotStatus = response.statusLine.statusCode
-                if (!this.statusEquals(response.statusLine.statusCode))
+                if (!this.statusEquals(gotStatus))
                     error("Status $gotStatus received, expected $status, URL: $url, Response body: $body")
                 return body
             }

--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -128,8 +128,8 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
 
         fun statusEquals(status: Int): Boolean {
             return this.status == status
-                    || (this.status == 200 && status == 302)
-                    || (this.status == 302 && status == 200)
+                    || (this.status == 200 && status == 304)
+                    || (this.status == 304 && status == 200)
         }
 
         // TODO Candidate for becoming a method on ShinySession that takes url/status args

--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -58,6 +58,14 @@ fun canIgnore(message: String):Boolean {
     return false
 }
 
+fun joinPaths(p1: String, p2: String): String {
+    return when(Pair(p1.endsWith("/"), p2.startsWith("/"))) {
+        Pair(true, true) -> p1 + p2.substring(1)
+        Pair(true, false), Pair(false, true) -> p1 + p2
+        else -> p1 + "/" + p2
+    }
+}
+
 sealed class Event(open val begin: Long, open val lineNumber: Int) {
     open fun sleepBefore(session: ShinySession): Long = 0
 
@@ -126,10 +134,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
         // TODO Candidate for becoming a method on ShinySession that takes url/status args
         fun get(session: ShinySession): String {
             val renderedUrl = session.replaceTokens(this.url)
-            val url = URIBuilderTiny(session.httpUrl)
-                    .appendRawPathsByString(renderedUrl)
-                    .build()
-                    .toString()
+            val url = joinPaths(session.httpUrl, renderedUrl)
 
             val cfg = RequestConfig.custom()
                     .setCookieSpec(CookieSpecs.STANDARD)
@@ -210,10 +215,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                        val datafile: String?): Http(begin, lineNumber, url, status) {
             override fun handle(session: ShinySession, out: PrintWriter) {
                 withLog(session, out) {
-                    val url = URIBuilderTiny(session.httpUrl)
-                            .appendRawPathsByString(session.replaceTokens(url))
-                            .build()
-                            .toString()
+                    val url = joinPaths(session.httpUrl, session.replaceTokens(url))
                     val cfg = RequestConfig.custom()
                             .setCookieSpec(CookieSpecs.STANDARD)
                             .build()


### PR DESCRIPTION
This PR fixes two problems discovered by a customer.

1. **Target URL slash-dropping** Unfortunately, the [uribuilder-tiny](https://github.com/moznion/uribuilder-tiny) library we used for URL manipulation in shinycannon did not conserve a trailing slash on the target URL if one was provided. This caused shinycannon to fail for the customer the way shinyloadtest did [until we fixed it](https://github.com/rstudio/shinyloadtest/pull/119). This PR addresses the problem conservatively by introducing a `joinPaths()` function containing the same logic the analogous function in shinyloadtest does. I call this approach conservative because there's a decent argument for either rolling our own URL builder, or for putting together a PR on `uribuilder-tiny`, but either would involve considerably more work.
2. **Status check bug** It's an error if an HTTP status code encountered during playback does not match one that was recorded, with the exception of 304 and 200 - they are considered equivalent to account for browser caching. The problem with the previous logic was when a code during recording was NOT 304 or 200, and was something else - like 404. A 404 encountered during recording is not necessarily a show-stopping error, and so 4xx requests are recorded like any other. shinycannon just expects to see the same code at playback time. However, even if the 404 was also encountered during playback, shinycannon considered 404 != 404, which made no sense. So, this PR simplifies the previous (confusing and wrong) set logic into a series of `==` checks.