### PR TITLE
Add --headers / -H to CLI parsing

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Detect.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Detect.kt
@@ -36,9 +36,7 @@ fun servedBy(appUrl: String, logger: Logger, headers: MutableList<Header> = muta
     if (url.host.matches("^.*\\.shinyapps\\.io$".toRegex()))
         return ServerType.SAI
 
-    val req = HttpGet(appUrl).apply {
-        headers.forEach { this.setHeader(it) }
-    }
+    val req = HttpGet(appUrl).addHeaders(headers)
     val resp = slurp(req)
 
     if (resp.hasHeader("x-ssp-xsrf") || resp.hasCookie("SSP-XSRF")) {

--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -2,7 +2,6 @@ package com.rstudio.shinycannon
 
 import com.google.gson.JsonParser
 import com.neovisionaries.ws.client.*
-import net.moznion.uribuildertiny.URIBuilderTiny
 import org.apache.http.client.config.CookieSpecs
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.methods.HttpGet
@@ -10,9 +9,9 @@ import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.FileEntity
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.util.EntityUtils
+import org.joda.time.Instant
 import java.io.PrintWriter
 import java.nio.file.FileSystems
-import org.joda.time.Instant
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
@@ -146,7 +145,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                     .setDefaultRequestConfig(cfg)
                     .setUserAgent(getUserAgent())
                     .build()
-            val get = HttpGet(url)
+            val get = HttpGet(url).addHeaders(session.headers)
             client.execute(get).use { response ->
                 val body = EntityUtils.toString(response.entity)
                 val gotStatus = response.statusLine.statusCode
@@ -226,7 +225,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                             .setDefaultRequestConfig(cfg)
                             .setUserAgent(getUserAgent())
                             .build()
-                    val post = HttpPost(url)
+                    val post = HttpPost(url).addHeaders(session.headers)
 
                     if (datafile != null) {
                         val parentDir = session.recording.toPath().parent ?: FileSystems.getDefault().getPath(".")
@@ -290,6 +289,8 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                             .cookies
                             .map { "${it.name}=${it.value}" }
                             .joinToString("; "))
+
+                    session.headers.forEach { h -> it.addHeader(h.name, h.value) }
 
                     it.addHeader("user-agent", getUserAgent())
 

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -385,6 +385,7 @@ class Args(parser: ArgParser) {
     val logLevel by parser.storing("Log level (default: warn, available include: debug, info, warn, error)") {
         Level.toLevel(this.toUpperCase(), Level.WARN) as Level
     }.default(Level.WARN)
+    val headers by parser.adding("-H", help = "A custom HTTP header to add to each request.")
 }
 
 class ArgsSerializer(): JsonSerializer<Args> {

--- a/src/main/kotlin/com/rstudio/shinycannon/ProtectedApp.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/ProtectedApp.kt
@@ -1,6 +1,7 @@
 package com.rstudio.shinycannon
 
 import net.moznion.uribuildertiny.URIBuilderTiny
+import org.apache.http.Header
 import org.apache.http.HttpEntity
 import org.apache.http.client.config.CookieSpecs
 import org.apache.http.client.config.RequestConfig
@@ -76,8 +77,8 @@ fun xpath(docString: String, query: String): Array<Node> {
 // XML collection type produced by the XPath API.
 operator fun NamedNodeMap.get(itemName: String): String = this.getNamedItem(itemName).nodeValue
 
-fun isProtected(appUrl: String): Boolean {
-    return setOf(403, 404).contains(slurp(HttpGet(appUrl)).statusCode)
+fun isProtected(appUrl: String, headers: MutableList<Header> = mutableListOf()): Boolean {
+    return setOf(403, 404).contains(slurp(HttpGet(appUrl).addHeaders(headers)).statusCode)
 }
 
 // Returns a Map of hidden inputs that must be posted along with
@@ -163,9 +164,14 @@ fun loginSSP(context: AuthContext, username: String, password: String): BasicCoo
     }
 }
 
-fun postLogin(appUrl: String, username: String, password: String, cookies: BasicCookieStore, logger: Logger): BasicCookieStore {
+fun postLogin(appUrl: String,
+              username: String,
+              password: String,
+              cookies: BasicCookieStore,
+              logger: Logger,
+              headers: MutableList<Header> = mutableListOf()): BasicCookieStore {
 
-    val resp = slurp(HttpGet(appUrl), cookies = cookies)
+    val resp = slurp(HttpGet(appUrl).addHeaders(headers), cookies = cookies)
     val server = servedBy(appUrl, logger)
     val inputs = getInputs(resp, server)
     val loginUrl = loginUrlFor(appUrl, server)


### PR DESCRIPTION
This addresses #48 through the addition of a new command-line argument, `-H/--header`, that allows users to add custom headers to every outbound HTTP request.

This should make it possible to use shinycannon with API key based auth, or with any other auth scheme involving custom headers.