### PR TITLE
Fix tests on SSP without reconnect

### DIFF
--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -276,6 +276,9 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                         override fun onError(websocket: WebSocket, cause: WebSocketException) {
                             session.fail(cause)
                         }
+                        override fun handleCallbackError(websocket: WebSocket, cause: Throwable) {
+                            session.fail(cause)
+                        }
 
                         override fun onDisconnected(websocket: WebSocket, serverCloseFrame: WebSocketFrame, clientCloseFrame: WebSocketFrame, closedByServer: Boolean) {
                             // In normal operation, the server should never close the websocket.

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -68,11 +68,22 @@ fun replaceTokens(s: String,
 }
 
 fun parseMessage(msg: String): JsonObject? {
+    // jcheng 2020-10-08: There are seeveral forms these messages can take. (I'm
+    // doing these from memory, in response to discovering that the "reconnect
+    // disabled" case seems not to have worked up til now.)
+    //
+    // Dev/SSOS: "{payload}"
+    // SSP/Connect, reconnect disabled: "a[0|m|{payload}" (where 0 is the subapp
+    //   number; because shinycannon doesn't support subapps, this number is
+    //   always zero)
+    // SSP/Connect, reconnect enabled: "a[A3#0|m|{payload}" (where A3 is a
+    //   message ID, these are nondeterministic and should be ignored)
+
     // If an unparsed message is from a reconnect-enabled server, it will have a
     // message ID on it. We want to ignore those for the purposes of looking at
     // matches, because they can vary sometimes (based on ignorable messages
     // sneaking into the message stream).
-    val normalized = msg.replace("""^a\["[0-9A-F]+""".toRegex(), """a["*""")
+    val normalized = msg.replace("""^a\["[0-9A-F]+#""".toRegex(), """a["*#""")
 
     val re = Pattern.compile("""^a\["(\*#)?0\|m\|(.*)"\]${'$'}""")
     val matcher = re.matcher(normalized)

--- a/src/test/kotlin/com/rstudio/shinycannon/Test.kt
+++ b/src/test/kotlin/com/rstudio/shinycannon/Test.kt
@@ -33,6 +33,16 @@ class Test {
     }
 
     @Test
+    fun testParseMessageNoReconnect() {
+        val m1 = """a["0|m|{\"config\":{\"sessionId\":\"a string inside\",\"user\":null}}"]"""
+        val parsed = parseMessage(m1)
+        Assert.assertEquals("a string inside", parsed?.get("config")?.asJsonObject?.get("sessionId")?.asString)
+
+        val m2 = """a["0|m|{\"config\":{\"workerId\":\"139eab2\",\"sessionId\":\"abcdefg\",\"user\":null}}"]"""
+        Assert.assertEquals("abcdefg", parseMessage(m2)?.get("config")?.asJsonObject?.get("sessionId")?.asString)
+    }
+
+    @Test
     fun testIgnore() {
         val ignorableMessages = listOf(
             """a["ACK 2"]""",


### PR DESCRIPTION
Also, failure to parse message was being swallowed (due to handleCallbackError
not being implemented).

Without this fix, running a recording against SSP with `reconnect off;` would result in messages about WS_RECV not being seen within 30 seconds, 60 seconds, etc. What's actually happening is that 1) the message isn't being parsed correctly and is throwing, and 2) that error is being swallowed. This PR fixes both problems.