### PR TITLE
Bump `receiveQueue` limit from 5 to 50

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # shinycannon (development)
 
-## Bug Fix and Improvements
+# shinycannon 1.1.0
 
 * Increased the `receiveQueue` limit from 5 to 50 to avoid queue limit errors when non-determinist custom messages are being sent out of order (#63)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Bug Fix and Improvements
 
+* Increased the `receiveQueue` limit from 5 to 50 to avoid queue limit errors when non-determinist custom messages are being sent out of order (#63)
 
 # shinycannon 1.1.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.rstudio</groupId>
     <artifactId>shinycannon</artifactId>
-    <version>1.1.0.9000</version>
+    <version>1.1.0.9001</version>
     <packaging>jar</packaging>
 
     <name>shinycannon</name>

--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -276,6 +276,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                                 session.logger.debug("%%% Ignoring $msg")
                             } else {
                                 session.logger.debug("%%% Received: $msg")
+                                session.logger.debug("%%% Message queue length: ${session.receiveQueue.size}")
                                 if (!session.receiveQueue.offer(WSMessage.String(session.replaceTokens(msg)))) {
                                     val queueSize = session.receiveQueueSize
                                     // This is possible when many `custom` messages are unexpectedly received!

--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -277,7 +277,9 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                             } else {
                                 session.logger.debug("%%% Received: $msg")
                                 if (!session.receiveQueue.offer(WSMessage.String(session.replaceTokens(msg)))) {
-                                    throw Exception("receiveQueue is full (max = ${session.receiveQueueSize})")
+                                    val queueSize = session.receiveQueueSize
+                                    // This is possible when many `custom` messages are unexpectedly received!
+                                    throw Exception("receiveQueue is full (max = $queueSize). If this error is occuring, please submit an GitHub issue with debug logs. Some unexpected WebSocket messages are being received")
                                 }
                             }
                         }

--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -280,7 +280,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                                 if (!session.receiveQueue.offer(WSMessage.String(session.replaceTokens(msg)))) {
                                     val queueSize = session.receiveQueueSize
                                     // This is possible when many `custom` messages are unexpectedly received!
-                                    throw Exception("receiveQueue is full (max = $queueSize). If this error is occuring, please submit an GitHub issue with debug logs. Some unexpected WebSocket messages are being received")
+                                    throw Exception("Message queue is full (max = $queueSize). If this error is occuring, please submit an GitHub issue with debug logs. Some unexpected WebSocket messages are being received")
                                 }
                             }
                         }

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -151,7 +151,7 @@ class ShinySession(val sessionId: Int,
     )
 
     var webSocket: WebSocket? = null
-    val receiveQueueSize = 5
+    val receiveQueueSize = 50
     val receiveQueue: LinkedBlockingQueue<WSMessage> = LinkedBlockingQueue(receiveQueueSize)
 
     var lastEventEnded: Long? = null


### PR DESCRIPTION
Example 

```
2021-11-22 13:06:27.713 ERROR [thread06] - Playback failed: receiveQueue is full (max = 5)
java.lang.Exception: receiveQueue is full (max = 5)
```

This can occur when `custom` messages are received out of order. (Non-deterministic. Very plausible situation.)

Previously, the queue had a size of `5`. Now it is set to `50`. 

--------------------------------

If app authors are sending enough non-deterministic custom messages to hit the new limit, I'd love to see what the app is doing and how we could address it.