### PR TITLE
WIP: Jupyter widget / shinywidgets support

### DIFF
--- a/jupyter-widget-support.md
+++ b/jupyter-widget-support.md
@@ -1,0 +1,112 @@
+# Jupyter Widget Support in Shinycannon
+
+## Background
+
+Shiny for Python apps using ipywidgets (via shinywidgets) produce WebSocket
+messages that shinycannon cannot currently handle correctly. This document
+describes the issues found and the fixes needed, based on investigation with a
+Plotly-based NBA dashboard app.
+
+## Bug 1: `replaceTokens` false positives on JavaScript template literals (FIXED)
+
+**Symptom:** `[D, E, W, I, Z, J] are illegal tokens`
+
+**Root cause:** `replaceTokens` in `Main.kt` uses the regex `\$\{([A-Z_]+)\}`
+to find token placeholders like `${SESSION}` and `${WORKER}`. When
+`shinywidgets_comm_open` messages contain minified JavaScript (e.g., plotly's
+ESM bundle via anywidget), the JS template literals `${D}`, `${E}`, etc. are
+false-positive matches. The function then rejects them as "illegal tokens."
+
+**Fix applied:** Changed `replaceTokens` to iterate over the known allowed
+tokens and replace only those, instead of finding all `${UPPERCASE}` patterns
+and then validating them. This makes it ignore `${...}` patterns that happen to
+appear in embedded JS code.
+
+## Bug 2: Empty message not recognized as ignorable (FIXED)
+
+**Symptom:** `Objects don't have same keys` — expected `{"custom":...}` but got
+`{"values":{},"inputMessages":[],"errors":{}}`
+
+**Root cause:** `canIgnore()` in `Events.kt` checks for the empty Shiny message
+`{"errors":[],"values":[],"inputMessages":[]}` (with empty arrays), but Python
+Shiny sends `{"values":{},"inputMessages":[],"errors":{}}` (with empty objects
+for `values` and `errors`). The equality check fails, so this no-op message
+enters the receive queue and gets compared against the next expected `WS_RECV`,
+which is a widget `custom` message — causing a key mismatch.
+
+**Fix applied:** Added the `{"values":{},"inputMessages":[],"errors":{}}` form
+as an additional recognized empty message pattern in `canIgnore()`.
+
+## Bug 3: Nondeterministic comm_id values (NOT YET FIXED)
+
+**Symptom:** After fixing bugs 1 and 2, playback will likely fail because
+`WS_SEND` messages reference `comm_id` values from the recording session, but
+the live server assigns different `comm_id` values.
+
+### How Jupyter widget comms work in shinywidgets
+
+1. Server sends `shinywidgets_comm_open` (via `WS_RECV`) with a `comm_id` and
+   widget state (which can be very large — plotly ESM bundles are hundreds of KB
+   of minified JS).
+2. Server sends `shinywidgets_comm_msg` (via `WS_RECV`) with state updates,
+   referencing the same `comm_id`.
+3. Client sends `shinywidgets_comm_send` (via `WS_SEND`) back to the server,
+   referencing the `comm_id` for user interactions and state echoes.
+
+### Key findings about IDs
+
+- **`comm_id`** is the primary nondeterministic identifier in the Jupyter comm
+  protocol. It is assigned by the server when a comm channel is opened.
+- **`model_id`** is the ipywidgets-level name for the same value. In every case
+  observed, `model_id == comm_id`. It appears in some `WS_RECV` messages but
+  NOT in `WS_SEND` messages (in the test recording).
+- **`ident`** fields like `"comm-432c2f5f..."` are derived from `comm_id`.
+- Other hex strings in `comm_open` messages (e.g., in `document.getElementById`
+  calls) are static IDs baked into the ESM JavaScript bundle, not
+  nondeterministic.
+- Plotly trace UIDs (e.g., `5abf2180-dd79-47ea-b4f5-23b4ca3a1f96`) appear only
+  in server-to-client messages, not in `WS_SEND`.
+
+### Proposed fix
+
+The approach is similar to how shinycannon already handles `${SESSION}`:
+
+1. **Capture the mapping during playback:** When processing a `WS_RECV` that
+   contains `shinywidgets_comm_open`, extract the `comm_id` from both the
+   recorded message and the actually-received message. Store a mapping of
+   `recorded_comm_id -> actual_comm_id`. Matching can be positional (the Nth
+   `comm_open` in the recording maps to the Nth in playback).
+
+2. **Replace IDs in outgoing messages:** Before sending any `WS_SEND` message,
+   do a string replacement of all mapped comm_ids throughout the entire message
+   body. This handles both `"comm_id": "..."` and `"model_id": "..."` fields
+   (and any other field referencing the same value) without needing to
+   understand the JSON structure.
+
+3. **Relax `WS_RECV` matching for widget messages:** The current `WS_RECV`
+   handler compares top-level JSON keys between the expected and received
+   messages. For `custom` messages containing widget data, the content will
+   differ between sessions (different comm_ids, different trace data, etc.), but
+   the structure should be the same. The existing top-level key comparison may
+   be sufficient if the empty-message fix (bug 2) prevents queue desync, but
+   this needs testing.
+
+### Residual risk
+
+At the Jupyter comm protocol level, `comm_id` is the only nondeterministic ID.
+Individual widgets could theoretically embed server-generated IDs inside their
+state payloads that the client echoes back, but this would be unusual widget
+design. This risk is acceptable to defer until someone hits it.
+
+## Build notes
+
+- JCenter (`jcenter.bintray.com`) is defunct. Removed it from `pom.xml`.
+- `kotlin-argparser` 2.0.3 was only on JCenter. Updated to 2.0.7 (available on
+  Maven Central). This required changing `.default(null)` to
+  `.default(null as Long?)` in `Main.kt` due to stricter type inference.
+
+## Test repro
+
+The reproduction case is in the `python-example-nba` directory of the
+`shinyloadtest-example` repo. The app is an NBA dashboard using Plotly
+FigureWidgets via shinywidgets. Run `run_test.sh` to reproduce.

--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,6 @@
         <main.class>com.rstudio.shinycannon.MainKt</main.class>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>BintrayJCenter</id>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -63,7 +56,7 @@
         <dependency>
             <groupId>com.xenomachina</groupId>
             <artifactId>kotlin-argparser</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -361,6 +361,21 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
                     check(expectingObj.keySet() == receivedObj?.keySet()) {
                         "Objects don't have same keys: $expectingObj, $receivedObj"
                     }
+
+                    // Extract comm_id mapping from shinywidgets_comm_open messages
+                    val expectingCustom = expectingObj.get("custom")?.asJsonObject
+                    val receivedCustom = receivedObj?.get("custom")?.asJsonObject
+                    if (expectingCustom != null && receivedCustom != null) {
+                        val commOpenKey = "shinywidgets_comm_open"
+                        if (expectingCustom.has(commOpenKey) && receivedCustom.has(commOpenKey)) {
+                            val recordedCommId = extractCommId(expectingCustom.get(commOpenKey).asString)
+                            val actualCommId = extractCommId(receivedCustom.get(commOpenKey).asString)
+                            if (recordedCommId != null && actualCommId != null) {
+                                session.commIdMapping[recordedCommId] = actualCommId
+                                session.logger.debug("Mapped comm_id: $recordedCommId -> $actualCommId")
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -423,7 +438,7 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
 
         override fun handle(session: ShinySession, out: PrintWriter) {
             withLog(session, out) {
-                val text = session.replaceTokens(message)
+                val text = session.replaceCommIds(session.replaceTokens(message))
                 session.webSocket!!.sendText(text)
                 session.logger.debug("WS_SEND sent: $text")
             }
@@ -442,4 +457,12 @@ sealed class Event(open val begin: Long, open val lineNumber: Int) {
             }
         }
     }
+}
+
+private fun extractCommId(commOpenJson: String): String? {
+    return try {
+        JsonParser.parseString(commOpenJson).asJsonObject
+                ?.get("content")?.asJsonObject
+                ?.get("comm_id")?.asString
+    } catch (e: Exception) { null }
 }

--- a/src/main/kotlin/com/rstudio/shinycannon/Events.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Events.kt
@@ -49,10 +49,11 @@ fun canIgnore(message: String):Boolean {
         return true
     }
 
-    val emptyMessage = JsonParser
-            .parseString("""{"errors":[],"values":[],"inputMessages":[]}""")
-            .asJsonObject
-    if (messageObject == emptyMessage) return true
+    val emptyMessages = listOf(
+            """{"errors":[],"values":[],"inputMessages":[]}""",
+            """{"values":{},"inputMessages":[],"errors":{}}"""
+    ).map { JsonParser.parseString(it).asJsonObject }
+    if (messageObject in emptyMessages) return true
 
     return false
 }

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -156,7 +156,15 @@ class ShinySession(val sessionId: Int,
 
     val cookieStore = BasicCookieStore()
 
+    val commIdMapping: LinkedHashMap<String, String> = linkedMapOf()
+
     fun replaceTokens(s: String) = replaceTokens(s, allowedTokens, tokenDictionary)
+
+    fun replaceCommIds(s: String): String {
+        return commIdMapping.entries.fold(s) { result, (recorded, actual) ->
+            result.replace(recorded, actual)
+        }
+    }
 
     private fun maybeLogin() {
       // Connect API Key has preference

--- a/src/main/kotlin/com/rstudio/shinycannon/Main.kt
+++ b/src/main/kotlin/com/rstudio/shinycannon/Main.kt
@@ -54,17 +54,16 @@ fun replaceTokens(s: String,
                   allowedTokens: HashSet<String>,
                   tokenDictionary: HashMap<String, String>): String {
 
-    val tokensInUrl = getTokens(s)
-
-    if (allowedTokens.union(tokensInUrl) != allowedTokens) {
-        val illegalTokens = tokensInUrl.filterNot { allowedTokens.contains(it) }
-        throw Exception("$illegalTokens are illegal tokens")
-    }
-
-    return tokensInUrl.fold(s) { newS, tokenName ->
-        if (!tokenDictionary.containsKey(tokenName))
-            throw Exception("$tokenName is an allowed token, but it isn't present in the dictionary")
-        newS.replace("\${$tokenName}", tokenDictionary[tokenName]!!, true)
+    // Only replace tokens that are in the allowed set. Other ${...} patterns
+    // (e.g. JavaScript template literals in minified widget code) are left as-is.
+    return allowedTokens.fold(s) { newS, tokenName ->
+        if ("\${$tokenName}" in newS) {
+            if (!tokenDictionary.containsKey(tokenName))
+                throw Exception("$tokenName is an allowed token, but it isn't present in the dictionary")
+            newS.replace("\${$tokenName}", tokenDictionary[tokenName]!!, true)
+        } else {
+            newS
+        }
     }
 }
 
@@ -457,7 +456,7 @@ class Args(parser: ArgParser) {
             .default(BigDecimal(5))
     val startInterval by parser.storing("Number of milliseconds to wait between starting workers. Defaults to the length of the recording divided by the number of workers.") {
         toLong()
-    }.default(null)
+    }.default(null as Long?)
     val headers by parser.adding("-H", "--header", help = "A custom HTTP header in the form 'name: value' to add to each request.") {
         parseHeader(this)
     }


### PR DESCRIPTION
## Summary

- Fix `replaceTokens` to ignore JavaScript template literals in minified widget code (plotly ESM bundles contain `${D}`, `${E}`, etc. that were falsely matched as shinycannon tokens)
- Recognize Python Shiny's empty message format (`{"values":{}}` with objects) in `canIgnore`, not just R Shiny's format (`{"values":[]}` with arrays)
- Remove dead JCenter repository from `pom.xml`, bump `kotlin-argparser` 2.0.3 → 2.0.7

## Still TODO

Comm ID mapping for Jupyter widgets — see `jupyter-widget-support.md` for full writeup. During playback, `comm_id` values assigned by the server differ from those in the recording, so `WS_SEND` messages that reference comm IDs will send stale values. The proposed fix is to capture a `recorded_comm_id → actual_comm_id` mapping from `shinywidgets_comm_open` messages and apply it to outgoing messages.

## Test plan

- [ ] Reproduce with `python-example-nba` from `shinyloadtest-example` repo (`run_test.sh`)
- [ ] Verify "illegal tokens" error is gone
- [ ] Verify empty message no longer causes queue desync
- [ ] Implement and test comm_id mapping (future work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)